### PR TITLE
Fix a kernel panic when attempting to remap.

### DIFF
--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -368,10 +368,22 @@ out:
 	return ret;
 }
 
+int xpmem_mapping_split(struct vm_area_struct *vma, unsigned long addr)
+{
+	/* From mm/mmap.c:
+	 * Forbid splitting special mappings - kernel has expectations over
+	 * the number of pages in mapping. Together with VM_DONTEXPAND
+	 * the size of vma should stay the same over the special mapping's
+	 * lifetime.
+	 */
+	return -EINVAL;
+}
+
 struct vm_operations_struct xpmem_vm_ops = {
 	.open = xpmem_open_handler,
 	.close = xpmem_close_handler,
-	.fault = xpmem_fault_handler
+	.fault = xpmem_fault_handler,
+	.may_split = xpmem_mapping_split
 };
 
 /*

--- a/xpmem-dkms.spec
+++ b/xpmem-dkms.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 %define intranamespace_name xpmem-dkms
-%define version 2.7.0
+%define version 2.7.1
 %define source_name %{intranamespace_name}-%{version}
 
 Summary: XPMEM: Cross-partition memory

--- a/xpmem-kmod.spec
+++ b/xpmem-kmod.spec
@@ -7,7 +7,7 @@
 
 Summary: XPMEM: Cross-partition memory
 Name: xpmem-kmod-%{kernel_release}
-Version: 2.7.0
+Version: 2.7.1
 Release: 0
 License: GPLv2
 Group: System Environment/Kernel


### PR DESCRIPTION
Linux now provides the may_split vm_operations_struct entry. Use this to disallow user attempts to remap attached mappings. Simply return -EINVAL.

Increment version to 2.7.1.

