### PR TITLE
Fix xpmem kernel build for RHEL9.6 (x86_64 and arm64)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([xpmem], [2.7.0], [https://github.com/Cray-HPE/xpmem])
+AC_INIT([xpmem], [1.0.0], [https://github.com/Cray-HPE/xpmem/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([include/xpmem.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/kernel/xpmem_attach.c
+++ b/kernel/xpmem_attach.c
@@ -541,14 +541,13 @@ xpmem_attach(struct file *file, xpmem_apid_t apid, off_t offset, size_t size,
 
 	vma->vm_private_data = att;
 
-#define RHEL_USE_VM_FLAGS_SET 0
 #if defined(RHEL_RELEASE_CODE)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,5)
 #define RHEL_USE_VM_FLAGS_SET 1
 #endif
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0) || RHEL_USE_VM_FLAGS_SET == 1
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0) || defined(RHEL_USE_VM_FLAGS_SET)
 	vm_flags_set(vma,
 		VM_DONTCOPY | VM_DONTDUMP | VM_IO | VM_DONTEXPAND | VM_PFNMAP);
 #else

--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -298,8 +298,14 @@ xpmem_pin_page(struct xpmem_thread_group *tg, struct task_struct *src_task,
 	/* Map with write permissions only if source VMA is writeable */
 	foll_write = (vma->vm_flags & VM_WRITE) ? FOLL_WRITE : 0;
 
+#if defined(RHEL_RELEASE_CODE)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,6) 
+#define RHEL_USE_GUP_6 1
+#endif
+#endif
+
 	/* get_user_pages()/get_user_pages_remote() faults and pins the page */
-#if   LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if   LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL_USE_GUP_6)
 	ret = get_user_pages_remote (src_mm, vaddr, 1, foll_write, &page, NULL);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
 	ret = get_user_pages_remote (src_mm, vaddr, 1, foll_write, &page, NULL,

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -69,8 +69,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x00026005
-#define XPMEM_CURRENT_VERSION_STRING	"2.6.5"
+#define XPMEM_CURRENT_VERSION		0x00027002
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.2"
 
 #define XPMEM_MODULE_NAME "xpmem"
 
@@ -492,5 +492,20 @@ xpmem_wait_for_seg_destroyed(struct xpmem_segment *seg)
 				       !(seg->flags & (XPMEM_FLAG_DESTROYING |
 						       XPMEM_FLAG_RECALLINGPFNS))));
 }
+
+#if defined(RHEL_RELEASE_CODE)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,6)
+static inline int pmd_large(pmd_t pte)
+{
+        return pmd_flags(pte) & _PAGE_PSE;
+}
+
+static inline int pud_large(pud_t pud)
+{
+        return (pud_val(pud) & (_PAGE_PSE | _PAGE_PRESENT)) ==
+                (_PAGE_PSE | _PAGE_PRESENT);
+}
+#endif
+#endif
 
 #endif /* _XPMEM_PRIVATE_H */

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -69,8 +69,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x00027002
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.2"
+#define XPMEM_CURRENT_VERSION		0x00027003
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.3"
 
 #define XPMEM_MODULE_NAME "xpmem"
 
@@ -494,6 +494,7 @@ xpmem_wait_for_seg_destroyed(struct xpmem_segment *seg)
 }
 
 #if defined(RHEL_RELEASE_CODE)
+#if defined(CONFIG_X86)
 #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,6)
 static inline int pmd_large(pmd_t pte)
 {
@@ -505,6 +506,7 @@ static inline int pud_large(pud_t pud)
         return (pud_val(pud) & (_PAGE_PSE | _PAGE_PRESENT)) ==
                 (_PAGE_PSE | _PAGE_PRESENT);
 }
+#endif
 #endif
 #endif
 

--- a/xpmem-dkms.spec
+++ b/xpmem-dkms.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 %define intranamespace_name xpmem-dkms
-%define version 2.7.2
+%define version %(grep "^#define[[:space:]]XPMEM_CURRENT_VERSION_STRING" kernel/xpmem_private.h | awk '{print $3}' | tr -d '"')
 %define source_name %{intranamespace_name}-%{version}
 
 Summary: XPMEM: Cross-partition memory

--- a/xpmem-dkms.spec
+++ b/xpmem-dkms.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 %define intranamespace_name xpmem-dkms
-%define version 2.7.1
+%define version 2.7.2
 %define source_name %{intranamespace_name}-%{version}
 
 Summary: XPMEM: Cross-partition memory

--- a/xpmem-kmod.spec
+++ b/xpmem-kmod.spec
@@ -2,12 +2,13 @@
 #define buildforkernels current
 #define buildforkernels akmod
 
+%define version %(grep "^#define[[:space:]]XPMEM_CURRENT_VERSION_STRING" kernel/xpmem_private.h | awk '{print $3}' | tr -d '"')
 %define kernel_release %(uname -r | sed -e 's/\.[^.]*$//g')
 %global debug_package %{nil}
 
 Summary: XPMEM: Cross-partition memory
 Name: xpmem-kmod-%{kernel_release}
-Version: 2.7.2
+Version: %{version} 
 Release: 0
 License: GPLv2
 Group: System Environment/Kernel

--- a/xpmem-kmod.spec
+++ b/xpmem-kmod.spec
@@ -7,7 +7,7 @@
 
 Summary: XPMEM: Cross-partition memory
 Name: xpmem-kmod-%{kernel_release}
-Version: 2.7.1
+Version: 2.7.2
 Release: 0
 License: GPLv2
 Group: System Environment/Kernel


### PR DESCRIPTION
Sync 2 commits from HPE internal xpmem repo.

Fix xpmem kernel build for RHEL9.6 (x86_64 and arm64)
    
Fix changes to get_user_pages_remote(), pud_large(), and pmd_large().
    
Refactor RHEL_USE_VM_FLAGS_SET for consistency.
    
Test Description: Built kernel module via dkms on RHEL9.6, RHEL9.5 and SLES15SP7 for both arm64 and x86_64.