### PR TITLE
Redo xpmem pud_large()/pmd_large() fix

### DIFF
--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -51,8 +51,8 @@
 #define pud_is_huge(p) (0)
 #endif
 #elif defined(CONFIG_X86)
-#define pmd_is_huge(p) pmd_large(p)
-#define pud_is_huge(p) pud_large(p)
+#define pmd_is_huge(p) pmd_leaf(p)
+#define pud_is_huge(p) pud_leaf(p)
 #elif defined(CONFIG_PPC)
 #define pmd_is_huge(p) pmd_large(p)
 #define pud_is_huge(p) ((pud_val(p) & 0x3) != 0x0)

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -69,8 +69,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x00027003
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.3"
+#define XPMEM_CURRENT_VERSION		0x00027006
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.6"
 
 #define XPMEM_MODULE_NAME "xpmem"
 
@@ -492,22 +492,5 @@ xpmem_wait_for_seg_destroyed(struct xpmem_segment *seg)
 				       !(seg->flags & (XPMEM_FLAG_DESTROYING |
 						       XPMEM_FLAG_RECALLINGPFNS))));
 }
-
-#if defined(RHEL_RELEASE_CODE)
-#if defined(CONFIG_X86)
-#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,6)
-static inline int pmd_large(pmd_t pte)
-{
-        return pmd_flags(pte) & _PAGE_PSE;
-}
-
-static inline int pud_large(pud_t pud)
-{
-        return (pud_val(pud) & (_PAGE_PSE | _PAGE_PRESENT)) ==
-                (_PAGE_PSE | _PAGE_PRESENT);
-}
-#endif
-#endif
-#endif
 
 #endif /* _XPMEM_PRIVATE_H */


### PR DESCRIPTION
 A prior commit pulled copies of pud_large()/pmd_large() into the xpmem source to account for RHEL changing symbol names.

The proper fix is to use pmd_leaf()/pud_leaf().

