### PR TITLE
Fix uninitialized variable found by valgrind

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([xpmem], [1.0.0], [https://github.com/Cray-HPE/xpmem/issues])
+AC_INIT([xpmem], [1.0.1], [https://github.com/Cray-HPE/xpmem/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([include/xpmem.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/lib/libxpmem.c
+++ b/lib/libxpmem.c
@@ -85,6 +85,7 @@ xpmem_segid_t xpmem_make(void *vaddr, size_t size, int permit_type,
 	make_info.size  = size;
 	make_info.permit_type  = permit_type;
 	make_info.permit_value = (__u64)permit_value;
+	make_info.segid = 0;
 	if (xpmem_ioctl(XPMEM_CMD_MAKE, &make_info) == -1 || !make_info.segid)
 		return -1;
 	return make_info.segid;
@@ -109,6 +110,7 @@ xpmem_apid_t xpmem_get(xpmem_segid_t segid, int flags, int permit_type,
 	get_info.flags = flags;
 	get_info.permit_type = permit_type;
 	get_info.permit_value = (__u64)NULL;
+	get_info.apid = 0;
 	if (xpmem_ioctl(XPMEM_CMD_GET, &get_info) == -1 || !get_info.apid)
 		return -1;
 	return get_info.apid;

--- a/xpmem-lib.spec
+++ b/xpmem-lib.spec
@@ -6,7 +6,7 @@
 
 Summary: XPMEM: Cross-partition memory
 Name: xpmem
-Version: 1.0.0
+Version: 1.0.1
 Release: 0
 License: GPLv2
 Group: System Environment/Libraries


### PR DESCRIPTION
Two struct entries were uninitialized.

