### PR TITLE
Enhance community xpmem to be namespace-aware

### DIFF
--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -69,8 +69,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x00027006
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.6"
+#define XPMEM_CURRENT_VERSION		0x00027007
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.7"
 
 #define XPMEM_MODULE_NAME "xpmem"
 


### PR DESCRIPTION
The community xpmem's xpmem_ipcperms() function has been enhanced to be user namespace aware similar to latest core kernel's ipcperms() function.


