### PR TITLE
Fix compute node crash in xpmem_vaddr_to_pte

### DIFF
--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -69,8 +69,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x00027007
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.7"
+#define XPMEM_CURRENT_VERSION		0x00027009
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.9"
 
 #define XPMEM_MODULE_NAME "xpmem"
 
@@ -87,6 +87,11 @@ extern uint32_t xpmem_debug_on;
 		printk("[%d]%s: "format"\n", current->tgid, __func__, ##a);
 
 #define delayed_work work_struct
+
+#if (defined(RHEL_MAJOR) && RHEL_MAJOR == 9 && RHEL_MINOR >= 3)
+extern void *(*xpmem_kln_ptr)(char *);
+#define kallsyms_lookup_name (*xpmem_kln_ptr)
+#endif
 
 /*
  * Both the xpmem_segid_t and xpmem_apid_t are of type __s64 and designed
@@ -305,6 +310,7 @@ extern const struct proc_ops xpmem_unpin_procfs_ops;
 /* found in xpmem_main.c */
 extern struct xpmem_partition *xpmem_my_part;
 void xpmem_teardown(struct xpmem_thread_group *tg);
+extern pte_t * (*p_huge_pte_offset) (struct mm_struct *mm, unsigned long addr, unsigned long sz);
 
 /* found in xpmem_misc.c */
 extern struct xpmem_thread_group *

--- a/usr/xpmem-kln.conf
+++ b/usr/xpmem-kln.conf
@@ -1,0 +1,1 @@
+install xpmem /sbin/modprobe --ignore-install xpmem xpmem_kln_arg=0x$(cat /proc/kallsyms | grep 'T kallsyms_lookup_name$' | cut -d ' ' -f 1)

--- a/xpmem-dkms.spec
+++ b/xpmem-dkms.spec
@@ -55,6 +55,10 @@ EOF
 %__install --mode=0644 usr/xpmem.conf %{buildroot}%{_modulesloaddir}/xpmem.conf
 %__mkdir_p %{buildroot}%{_udevrulesdir}
 %__install --mode=0644 usr/56-xpmem.rules %{buildroot}%{_udevrulesdir}/56-xpmem.rules
+%if 0%{?rhel}
+%__mkdir_p %{buildroot}%{_sysconfdir}/modprobe.d
+%__install --mode=0644 usr/xpmem-kln.conf %{buildroot}%{_sysconfdir}/modprobe.d/xpmem.conf
+%endif
 
 %preun
 /usr/sbin/dkms remove -m %{intranamespace_name} -v %{version}-%{release} --all --rpm_safe_upgrade
@@ -76,3 +80,7 @@ fi
 %{_modulesloaddir}/xpmem.conf
 %dir %{_udevrulesdir}
 %{_udevrulesdir}/56-xpmem.rules
+%if 0%{?rhel}
+%dir %{_sysconfdir}/modprobe.d
+%{_sysconfdir}/modprobe.d/xpmem.conf
+%endif


### PR DESCRIPTION
A possible race between a process(that created xpmem memory region) trying to migrate the Transparent Huge Page(THP) pages and another process(that attach to that memory region) faulting on the same THP pages may cause a system crash. To handle the race, the code has been enhanced accordingly.


