### PR TITLE
Port cray-xpmem's race fix

### DIFF
--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -69,8 +69,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x0002700B
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.11"
+#define XPMEM_CURRENT_VERSION		0x0002700C
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.12"
 
 #define XPMEM_MODULE_NAME "xpmem"
 


### PR DESCRIPTION
There exists a race between xpmem_fault_handler and core kernel functionality like page migration. This race was fixed in cray xpmem by introducing page table locking mechanism. Similar changes is been ported into community xpmem as well.

TEST: The fix has been validated in SLES and RHEL
environment by loading, rebuilding, reloading, etc. The fix has been validated using xpmem-test testsuites including migration test.

