### PR TITLE
Thread group cleanup issue.

### DIFF
--- a/kernel/xpmem_main.c
+++ b/kernel/xpmem_main.c
@@ -110,10 +110,12 @@ xpmem_open(struct inode *inode, struct file *file)
 	}
 
 	snprintf(tgid_string, XPMEM_TGID_STRING_LEN, "%d", current->tgid);
+	mutex_lock(&xpmem_unpin_procfs_mutex);
 	unpin_entry = proc_create_data(tgid_string, 0644,
 				       xpmem_unpin_procfs_dir,
 				       &xpmem_unpin_procfs_ops,
 				       (void *)(unsigned long)current->tgid);
+	mutex_unlock(&xpmem_unpin_procfs_mutex);
 	if (unpin_entry != NULL) {
 		proc_set_user(unpin_entry, current_uid(), current_gid());
 	}
@@ -151,14 +153,28 @@ xpmem_open(struct inode *inode, struct file *file)
 static void
 xpmem_destroy_tg(struct xpmem_thread_group *tg)
 {
+	bool do_unhash;
+	int index;
+
 	XPMEM_DEBUG("tg->mm=%p", tg->mm);
 
 	/*
 	 * Calls MMU release function if exit_mmap() has not executed yet.
 	 * Decrements mm_count.
 	 */
-	xpmem_mmu_notifier_unlink(tg);
-	xpmem_tg_destroyable(tg);
+	do_unhash = xpmem_mmu_notifier_unlink(tg);
+	if(do_unhash) {
+		/* Remove tg structure from its hash list */
+		index = xpmem_tg_hashtable_index(tg->tgid);
+
+		write_lock(&xpmem_my_part->tg_hashtable[index].lock);
+		BUG_ON(list_empty(&tg->tg_hashlist));
+		list_del_init(&tg->tg_hashlist);
+		write_unlock(&xpmem_my_part->tg_hashtable[index].lock);
+
+		xpmem_tg_destroyable(tg);
+
+	}
 	xpmem_tg_deref(tg);
 }
 
@@ -243,8 +259,6 @@ xpmem_flush(struct file *file, fl_owner_t owner)
 		 */
 		return 0;
 	}
-
-	list_del_init(&tg->tg_hashlist);
 
 	write_unlock(&xpmem_my_part->tg_hashtable[index].lock);
 
@@ -447,6 +461,7 @@ xpmem_init(void)
 	}
 
 	/* create the /proc interface directory (/proc/xpmem) */
+	mutex_init(&xpmem_unpin_procfs_mutex);
 	xpmem_unpin_procfs_dir = proc_mkdir(XPMEM_MODULE_NAME, NULL);
 	if (xpmem_unpin_procfs_dir == NULL) {
 		ret = -EBUSY;

--- a/kernel/xpmem_mmu_notifier.c
+++ b/kernel/xpmem_mmu_notifier.c
@@ -253,17 +253,19 @@ xpmem_mmu_notifier_init(struct xpmem_thread_group *tg)
 /*
  * Unlink MMU notifier callbacks
  */
-void
+bool
 xpmem_mmu_notifier_unlink(struct xpmem_thread_group *tg)
 {
 	spin_lock(&tg->lock);
 	if (!tg->mmu_initialized || tg->mmu_unregister_called) {
 		spin_unlock(&tg->lock);
-		return;
+		return false;
 	}
 	tg->mmu_unregister_called = 1;
 	spin_unlock(&tg->lock);
 
 	XPMEM_DEBUG("tg->mm=%p", tg->mm);
 	mmu_notifier_unregister(&tg->mmu_not, tg->mm);
+
+	return true;
 }

--- a/kernel/xpmem_pfn.c
+++ b/kernel/xpmem_pfn.c
@@ -651,6 +651,7 @@ xpmem_fork_end(void)
 	return 0;
 }
 
+struct mutex xpmem_unpin_procfs_mutex;
 struct proc_dir_entry *xpmem_unpin_procfs_dir;
 
 static int

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -70,8 +70,8 @@
  *       major - major revision number (12-bits)
  *       minor - minor revision number (16-bits)
  */
-#define XPMEM_CURRENT_VERSION		0x0002700D
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.13"
+#define XPMEM_CURRENT_VERSION		0x0002700E
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.14"
 
 #define XPMEM_MODULE_NAME "xpmem"
 
@@ -300,6 +300,7 @@ extern void xpmem_unblock_recall_PFNs(struct xpmem_thread_group *);
 extern int xpmem_fork_begin(void);
 extern int xpmem_fork_end(void);
 #define XPMEM_TGID_STRING_LEN	11
+extern struct mutex xpmem_unpin_procfs_mutex;
 extern struct proc_dir_entry *xpmem_unpin_procfs_dir;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
 extern struct file_operations xpmem_unpin_procfs_ops;
@@ -372,7 +373,7 @@ extern const struct proc_ops xpmem_debug_printk_procfs_ops;
 #endif
 /* found in xpmem_mmu_notifier.c */
 extern int xpmem_mmu_notifier_init(struct xpmem_thread_group *);
-extern void xpmem_mmu_notifier_unlink(struct xpmem_thread_group *);
+extern bool xpmem_mmu_notifier_unlink(struct xpmem_thread_group *);
 
 /*
  * Inlines that mark an internal driver structure as being destroyable or not.


### PR DESCRIPTION
Multiple calls to close the same open instance of
/dev/xpmem can cause a race condition which can
prevent proper clean up of thread group.
Changes are made to ensure, thread group is removed from hash only after MMU notifier clean up completes.

Testing:
Ran functional tests on SP7 and RHEL and no issues were seen.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

