### PR TITLE
Fix for excessive kernel warnings from xpmem flush operation

### DIFF
--- a/kernel/xpmem_main.c
+++ b/kernel/xpmem_main.c
@@ -269,7 +269,9 @@ xpmem_flush(struct file *file, fl_owner_t owner)
 	 * and the distruction of the thread group object.
 	 */
 	snprintf(tgid_string, XPMEM_TGID_STRING_LEN, "%d", tg->tgid);
+	mutex_lock(&xpmem_unpin_procfs_mutex);
 	remove_proc_entry(tgid_string, xpmem_unpin_procfs_dir);
+	mutex_unlock(&xpmem_unpin_procfs_mutex);
 
 	xpmem_destroy_tg(tg);
 

--- a/kernel/xpmem_misc.c
+++ b/kernel/xpmem_misc.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2004-2007 Silicon Graphics, Inc.  All Rights Reserved.
  * Copyright 2009, 2010, 2014 Cray Inc. All Rights Reserved
  * Copyright 2017-2020 Arm, Inc. All Rights Reserved
+ * Copyright Hewlett Packard Enterprise Development LP. All Rights Reserved.
  */
 
 /*
@@ -86,8 +87,6 @@ xpmem_tg_ref_by_apid(xpmem_apid_t apid)
 void
 xpmem_tg_deref(struct xpmem_thread_group *tg)
 {
-	char tgid_string[XPMEM_TGID_STRING_LEN];
-
 	DBUG_ON(atomic_read(&tg->refcnt) <= 0);
 	if (atomic_dec_return(&tg->refcnt) != 0)
 		return;
@@ -105,11 +104,6 @@ xpmem_tg_deref(struct xpmem_thread_group *tg)
 	 * the extra increment previously done in xpmem_open().
 	 */
 	put_task_struct(tg->group_leader);
-
-	snprintf(tgid_string, XPMEM_TGID_STRING_LEN, "%d", tg->tgid);
-	mutex_lock(&xpmem_unpin_procfs_mutex);
-	remove_proc_entry(tgid_string, xpmem_unpin_procfs_dir);
-	mutex_unlock(&xpmem_unpin_procfs_mutex);
 
 	kfree(tg);
 }

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -71,8 +71,8 @@
  *       minor - minor revision number (16-bits)
  */
 
-#define XPMEM_CURRENT_VERSION		0x00027010
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.16"
+#define XPMEM_CURRENT_VERSION		0x00027011
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.17"
 
 #define XPMEM_MODULE_NAME "xpmem"
 


### PR DESCRIPTION
An additional call to remove_proc_entry() was added as part of fcdf26ce. This resulted in it attempting to remove already removed entry from the procfs, resulting in kernel warnings.

Testing:
The kernel warnings are no longer seen after the code changes. xpmem functional tests were run with no failures.
Tested on RHEL and SLES 15 SP7
