### PR TITLE
Fix a bug in xpmem_mmu_release()

### DIFF
--- a/kernel/xpmem_mmu_notifier.c
+++ b/kernel/xpmem_mmu_notifier.c
@@ -228,7 +228,7 @@ xpmem_mmu_release(struct mmu_notifier *mn, struct mm_struct *mm)
 			if (tg->mm == mm) {
 				int call_teardown;
 				call_teardown = xpmem_tg_set_destroying(tg);
-				if (!call_teardown);
+				if (!call_teardown)
 					continue;
 
 				xpmem_tg_ref(tg);

--- a/kernel/xpmem_private.h
+++ b/kernel/xpmem_private.h
@@ -71,8 +71,8 @@
  *       minor - minor revision number (16-bits)
  */
 
-#define XPMEM_CURRENT_VERSION		0x00027011
-#define XPMEM_CURRENT_VERSION_STRING	"2.7.17"
+#define XPMEM_CURRENT_VERSION		0x00027012
+#define XPMEM_CURRENT_VERSION_STRING	"2.7.18"
 
 #define XPMEM_MODULE_NAME "xpmem"
 


### PR DESCRIPTION
An extra semi-colon short-circuits some of the teardown logic. Remove it.

